### PR TITLE
Add support to arrays in mailgun custom_vars

### DIFF
--- a/lib/swoosh/adapters/mailgun.ex
+++ b/lib/swoosh/adapters/mailgun.ex
@@ -28,9 +28,9 @@ defmodule Swoosh.Adapters.Mailgun do
   - `:template_name` (template)
   - `:recipient_vars` (recipient-variables)
   - `:tags` (o:tag, added before `:sending_options`)
-  
+
   ## Custom headers
-  
+
   Headers added via `Email.header/3` will be translated to (h:) values that Mailgun recognizes.
   """
 
@@ -102,9 +102,7 @@ defmodule Swoosh.Adapters.Mailgun do
   # %{"my_var" => %{"my_message_id": 123},
   #   "my_other_var" => %{"my_other_id": 1, "stuff": 2}}
   defp prepare_custom_vars(body, %{provider_options: %{custom_vars: custom_vars}}) do
-    Enum.reduce(custom_vars, body, fn {k, v}, body ->
-      Map.put(body, "v:#{k}", encode_variable(v))
-    end)
+    Map.put(body, "h:X-Mailgun-Variables", Swoosh.json_library().encode!(custom_vars))
   end
 
   defp prepare_custom_vars(body, _email), do: body

--- a/test/swoosh/adapters/mailgun_test.exs
+++ b/test/swoosh/adapters/mailgun_test.exs
@@ -73,7 +73,7 @@ defmodule Swoosh.Adapters.MailgunTest do
                       "from" => ~s("T Stark" <tony.stark@example.com>),
                       "text" => "Hello",
                       "html" => "<h1>Hello</h1>",
-                      "v:key" => "value",
+                      "h:X-Mailgun-Variables" => "{\"key\":\"value\"}",
                       "template" => "avengers-templates"}
       assert body_params == conn.body_params
       assert expected_path == conn.request_path
@@ -92,7 +92,7 @@ defmodule Swoosh.Adapters.MailgunTest do
       |> to("steve.rogers@example.com")
       |> subject("Hello, Avengers!")
       |> html_body("<h1>Hello</h1>")
-      |> put_provider_option(:custom_vars, %{my_var: %{my_message_id: 123}, my_other_var: %{my_other_id: 1, stuff: 2}})
+      |> put_provider_option(:custom_vars, %{my_var: [%{my_message_id: 123}], my_other_var: %{my_other_id: 1, stuff: 2}})
 
     Bypass.expect bypass, fn conn ->
       conn = parse(conn)
@@ -101,8 +101,7 @@ defmodule Swoosh.Adapters.MailgunTest do
                       "to" => "steve.rogers@example.com",
                       "from" => "tony.stark@example.com",
                       "html" => "<h1>Hello</h1>",
-                      "v:my_var" => "{\"my_message_id\":123}",
-                      "v:my_other_var" => "{\"my_other_id\":1,\"stuff\":2}"}
+                      "h:X-Mailgun-Variables" => "{\"my_other_var\":{\"my_other_id\":1,\"stuff\":2},\"my_var\":[{\"my_message_id\":123}]}"}
       assert body_params == conn.body_params
       assert expected_path == conn.request_path
       assert "POST" == conn.method


### PR DESCRIPTION
The current way to send variables is to use a form parameter, which is not recomended as it’s limited to simple key value data. If you have arrays, dictionaries in values or complex json data you have to supply variables via X-Mailgun-Variables header.

https://documentation.mailgun.com/en/latest/user_manual.html#templates